### PR TITLE
Fix bugs and add docs

### DIFF
--- a/data/info.rkt
+++ b/data/info.rkt
@@ -1,0 +1,3 @@
+#lang info
+(define scribblings
+  '(("p-array.scrbl" () (library) "persistent-array")))

--- a/data/p-array.rkt
+++ b/data/p-array.rkt
@@ -69,7 +69,7 @@
 (define set
   (lambda (t i v)
     (cond
-      ((= i v) t)
+      ((equal? (get t i) v) t)
       (else
        (reroot t)
        (let ((t^ (unbox t)))

--- a/data/p-array.rkt
+++ b/data/p-array.rkt
@@ -22,9 +22,10 @@
          (let ((f (extendable-arr-f t^))
                (v (extendable-arr-v t^)))
            (let ((size (vector-length v)))
-             (let ((new-v (vector-append v (build-vector size (f size)))))
-               (set-box! t (make-extendable-arr f new-v))
-               t))))
+             (let ((new-f (λ (i) (f (+ i size)))))
+               (let ((new-v (vector-append v (build-vector size new-f))))
+                 (set-box! t (make-extendable-arr f new-v))
+                 t)))))
         (else
          (extend (Diff-t t^))
          t)))))
@@ -34,7 +35,7 @@
 
 (define create
   (lambda (size f)
-    (box (make-extendable-arr f (build-vector size (f 0))))))
+    (box (make-extendable-arr f (build-vector size f)))))
 
 (define reroot
   (lambda (t)

--- a/data/p-array.rkt
+++ b/data/p-array.rkt
@@ -3,7 +3,8 @@
 (provide (rename-out [get p-array-ref]
                      [set p-array-set]
                      [create make-p-array]
-                     [extend p-array-resize]))
+                     [extend p-array-resize]
+                     [extendable-arr? p-array?]))
 
 ;; Jason Hemann and Dan Friedman
 

--- a/data/p-array.scrbl
+++ b/data/p-array.scrbl
@@ -1,6 +1,9 @@
 #lang scribble/manual
 
-@(require scribble/example)
+@(require (for-label data/p-array
+                     racket/base
+                     racket/contract/base)
+          scribble/example)
 
 @(define (make-parr-eval)
    (make-base-eval #:lang 'racket/base

--- a/data/p-array.scrbl
+++ b/data/p-array.scrbl
@@ -1,0 +1,69 @@
+#lang scribble/manual
+
+@(require scribble/example)
+
+@(define (make-parr-eval)
+   (make-base-eval #:lang 'racket/base
+                   '(require data/p-array)))
+
+@(define-syntax-rule (parr-examples body ...)
+   (examples #:eval (make-parr-eval) body ...))
+
+@title{Semi-Persistent Arrays}
+@author["Jason Hemann"
+        "Dan Friedman"
+        @author+email["Sam Tobin-Hochstadt"
+                      "samth@ccs.neu.edu"]]
+@defmodule[data/p-array]
+
+This library provides an implementation of
+@deftech[#:key "semi-persistent array"]{semi-persistent arrays}. Semi-persistent
+arrays present functional get and set operations that return new arrays
+efficiently, but existing arrays may be modified under the covers during
+construction of new arrays. Thus the data structure is persistent, but neither
+thread safe nor implemented in a purely functional manner. See
+@hyperlink["https://www.lri.fr/~filliatr/ftp/publis/puf-wml07.pdf"]{A Persistent
+ Union-Find Data Structure} by Sylvain Conchon and Jean-Christophe Filliâtre for
+more details.
+
+@defproc[(p-array? [v any/c]) boolean?]{
+ Returns @racket[#t] if @racket[v] is a @tech{semi-persistent array}, returns
+ @racket[#f] otherwise.}
+
+@defproc[(make-p-array [size fixnum?]
+                       [build-item (-> exact-nonnegative-integer? any/c)])
+         p-array?]{
+ Returns a @tech{semi-persistent array} containing @racket[size] items, where
+ each item is the result of applying @racket[build-item] to its position in the
+ array (similarly to @racket[build-list] and @racket[build-vector]).
+
+ @(parr-examples
+   (make-p-array 5 (λ (i) (* i 10))))}
+
+@defproc[(p-array-ref [parr p-array?] [i fixnum?]) any/c]{
+ Returns the element of @racket[parr] at position @racket[i] in amortized
+ constant space and time.
+
+ @(parr-examples
+   (eval:check (p-array-ref (make-p-array 5 values) 2) 2))}
+
+@defproc[(p-array-set [parr p-array?] [i fixnum?] [v any/c]) p-array?]{
+ Returns a new @tech{semi-persistent array} that is equivalent to @racket[parr]
+ with @racket[v] at position @racket[i]. The new array is constructed in
+ amortized constant space and time.
+
+ @(parr-examples
+   (define changed-arr
+     (p-array-set (make-p-array 5 values) 4 'foo))
+   (eval:check (p-array-ref changed-arr 4) 'foo))}
+
+@defproc[(p-array-resize [parr p-array?]) p-array?]{
+ Returns a new @tech{semi-persistent array} that is equivalent to @racket[parr]
+ with its size doubled. New positions in the array are filled using the initial
+ @racket[build-item] procedure provided during the construction of @racket[parr]
+ with @racket[make-p-array].
+
+ @(parr-examples
+   (define resized (p-array-resize (make-p-array 5 values)))
+   resized
+   (eval:check (p-array-ref resized 7) 7))}

--- a/info.rkt
+++ b/info.rkt
@@ -1,3 +1,5 @@
 #lang info
 (define collection 'multi)
 (define deps '("base"))
+(define build-deps '("racket-doc"
+                     "scribble-lib"))


### PR DESCRIPTION
Adds documentation with examples and fixes a few bugs:

- Constructing a persistent array would fail due to a bug in how `build-vector` was used
- Updating a persistent array would fail due to a bug in how the old value at an array index and the new value were compared
- Extending a persistent array would fail due to a bug similar to the one that caused construction to fail
- The predicate identifying persistent arrays wasn't provided, so it was impossible to write contracts referencing them

One less package server TODO!